### PR TITLE
fix ffmpeg ADTS to ASC error, add requirements.txt

### DIFF
--- a/murrtube-dl.py
+++ b/murrtube-dl.py
@@ -26,6 +26,7 @@ def download_video(url):
                 "ffmpeg",
                 "-i", video_url,
                 "-c", "copy",
+                "-bsf:a", "aac_adtstoasc", # convert MPEG ADTS
                 output_filename
             ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+requests


### PR DESCRIPTION
* fix the following ffmpeg error on some videos:

```
[mp4 @ 0000000003569980] Malformed AAC bitstream detected: use audio bitstream filter 'aac_adtstoasc' to fix it ('-bsf:a aac_adtstoasc' option with ffmpeg)
av_interleaved_write_frame(): Operation not permitted
```

* add requirements.txt